### PR TITLE
[SWP] Fix a bug in SWP that did not correctly compute the number of loop iterations

### DIFF
--- a/include/triton/Dialect/TritonGPU/Transforms/PipelineExpander.h
+++ b/include/triton/Dialect/TritonGPU/Transforms/PipelineExpander.h
@@ -57,6 +57,10 @@ struct PipeliningOption {
   /// pipeliner will have to predicate operations in the the prologue/epilogue.
   bool supportDynamicLoops = false;
 
+  /// The number of stages to use for the pipelining. Generally, it comes from
+  /// ``tt.num_stages``.
+  int numStages = 0;
+
   // Callback to predicate operations when the prologue or epilogue are not
   // peeled. This takes the original operation, an i1 predicate value and the
   // pattern rewriter. It is expected to replace the given operation with

--- a/lib/Dialect/TritonGPU/Transforms/Pipeliner/MatmulLoopPipeline.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/Pipeliner/MatmulLoopPipeline.cpp
@@ -1171,6 +1171,7 @@ bool mlir::triton::preProcessLoopAndGetSchedule(
   options.peelEpilogue = false;
   options.predicateFn = tt::predicateOp;
   options.supportDynamicLoops = true;
+  options.numStages = numStages;
   options.annotateFn = [](Operation *op,
                           mlir::triton::PipeliningOption::PipelinerPart part,
                           unsigned iteration) {};

--- a/python/test/unit/test_perf_warning.py
+++ b/python/test/unit/test_perf_warning.py
@@ -175,3 +175,25 @@ def test_remark_swp_op_before_operands(capfd, fresh_triton_cache):
     _, err = capfd.readouterr()
 
     assert "operation scheduled before its operands" in err, "expect swp op remark"
+
+
+def test_remark_swp_num_stages_greater_than_loop_iters(capfd, fresh_triton_cache):
+
+    @triton.jit
+    def kernel_pipe_num_stages_gt_loop_iters(in_ptr, out_ptr):
+        SIZE: tl.constexpr = 64
+        in_ptrs = in_ptr + tl.arange(0, SIZE)
+        for i in tl.range(0, 2, num_stages=4):
+            val = tl.load(in_ptrs)
+            in_ptrs += SIZE
+            out_ptrs = out_ptr + (tl.arange(0, SIZE) + i * SIZE)
+            tl.store(out_ptrs, val)
+
+    with enable_remark_context():
+        triton.compile(
+            triton.compiler.ASTSource(fn=kernel_pipe_num_stages_gt_loop_iters,                 signature={"in_ptr": "*fp32", "out_ptr": "*fp32"},
+                                      constants={}), options={"cluster_dims": (1, 1, 1)})
+
+    _, err = capfd.readouterr()
+    assert ("remark: fewer loop iterations than pipeline stages"
+            in err), "expect performance warning remark:" + err

--- a/python/test/unit/test_perf_warning.py
+++ b/python/test/unit/test_perf_warning.py
@@ -191,9 +191,9 @@ def test_remark_swp_num_stages_greater_than_loop_iters(capfd, fresh_triton_cache
 
     with enable_remark_context():
         triton.compile(
-            triton.compiler.ASTSource(fn=kernel_pipe_num_stages_gt_loop_iters,                 signature={"in_ptr": "*fp32", "out_ptr": "*fp32"},
-                                      constants={}), options={"cluster_dims": (1, 1, 1)})
+            triton.compiler.ASTSource(fn=kernel_pipe_num_stages_gt_loop_iters,
+                                      signature={"in_ptr": "*fp32", "out_ptr": "*fp32"}, constants={}),
+            options={"cluster_dims": (1, 1, 1)})
 
     _, err = capfd.readouterr()
-    assert ("remark: fewer loop iterations than pipeline stages"
-            in err), "expect performance warning remark:" + err
+    assert ("remark: fewer loop iterations than pipeline stages" in err), "expect performance warning remark:" + err


### PR DESCRIPTION
This PR is picked from #4689 for clarity. Prior to this PR, the loop lower and outer bound for `tl.range` was incorrect. Now it correctly casts to the data type that holds the bounds in `tl.range`. Also, prior to this PR, the `maxStage` was set to zero, and we correctly set it to the value come from `num_stages` in `tl.range`.

It is likely that it's directly inherited from the MLIR upstream pipelining algorithm: https://github.com/llvm/llvm-project/blob/main/mlir/lib/Dialect/SCF/Transforms/LoopPipelining.cpp#L110. However, seems Triton uses different data types from the MLIR upstream algorithm.

- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [x] I have added tests.
    - `/python/test` for end-to-end tests

- Select one of the following.
  - [x] I have not added any `lit` tests.